### PR TITLE
Remove leftover pdb debug statement

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,3 @@
-import pdb; pdb.set_trace()  # Add this line where you want to start debugging
-
 from flask import Flask, render_template, request, redirect, url_for, send_file, jsonify, g
 import mysql.connector
 import pandas as pd


### PR DESCRIPTION
## Summary
- remove `import pdb; pdb.set_trace()` from `app.py`
- ensure `app.py` starts with Flask import

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685c76f28f08832c942617c9ae4e9b68