### PR TITLE
Fix decade distribution return values

### DIFF
--- a/app.py
+++ b/app.py
@@ -521,7 +521,7 @@ class GeorgiaFantasy5Predictor:
     
     def calculate_decade_distribution(self, numbers):
         """Calculate how many numbers fall in each decade (1-9, 10-19, 20-29, 30-39, 40-42)"""
-        d0, d1, d2, d3 = 0, 0, 0, 0
+        d0, d1, d2, d3, d4 = 0, 0, 0, 0, 0
         
         for num in numbers:
             if 1 <= num <= 9:
@@ -532,10 +532,10 @@ class GeorgiaFantasy5Predictor:
                 d2 += 1
             elif 30 <= num <= 39:
                 d3 += 1
-            else:                   ###250626 ###
-                d4 += 1             ###250626 ###
-        
-        return d0, d1, d2, d3, d4   ###250626 ###
+            else:
+                d4 += 1
+
+        return d0, d1, d2, d3, d4
     
     def calculate_duplicates_from_previous(self, numbers, max_draws=10):
         """
@@ -613,7 +613,7 @@ class GeorgiaFantasy5Predictor:
             
         # Decade distribution check
         d0, d1, d2, d3, d4 = self.calculate_decade_distribution(combination)
-        if d0 > 2 or d1 > 2 or d2 > 2 or d3 > 2 or d4 > 2:  ### 250626 ###
+        if d0 > 2 or d1 > 2 or d2 > 2 or d3 > 2 or d4 > 2:
             return False
             
         # Duplicate check from previous draws
@@ -968,8 +968,6 @@ class GeorgiaFantasy5Predictor:
         odd_count = len(numbers) - even_count
         
         # Decade distribution
-        d0, d1, d2, d3, d4 = self.calculate_decade_distribution(numbers)    ### 250626 ###
-        
         # Sequential checks
         seq2, seq3 = self.count_sequential_numbers(numbers)
         

--- a/app.py.bak
+++ b/app.py.bak
@@ -520,8 +520,8 @@ class GeorgiaFantasy5Predictor:
         return mod_total, mod_x
     
     def calculate_decade_distribution(self, numbers):
-        """Calculate how many numbers fall in each decade (1-9, 10-19, 20-29, 30-39)"""
-        d0, d1, d2, d3 = 0, 0, 0, 0
+        """Calculate how many numbers fall in each decade (1-9, 10-19, 20-29, 30-39, 40-42)"""
+        d0, d1, d2, d3, d4 = 0, 0, 0, 0, 0
         
         for num in numbers:
             if 1 <= num <= 9:
@@ -532,10 +532,10 @@ class GeorgiaFantasy5Predictor:
                 d2 += 1
             elif 30 <= num <= 39:
                 d3 += 1
-            else:                   ###250626 ###
-                d4 += 1             ###250626 ###
-        
-        return d0, d1, d2, d3, d4   ###250626 ###
+            else:
+                d4 += 1
+
+        return d0, d1, d2, d3, d4
     
     def calculate_duplicates_from_previous(self, numbers, max_draws=10):
         """
@@ -613,7 +613,7 @@ class GeorgiaFantasy5Predictor:
             
         # Decade distribution check
         d0, d1, d2, d3, d4 = self.calculate_decade_distribution(combination)
-        if d0 > 2 or d1 > 2 or d2 > 2 or d3 > 2 or d4 > 2:  ### 250626 ###
+        if d0 > 2 or d1 > 2 or d2 > 2 or d3 > 2 or d4 > 2:
             return False
             
         # Duplicate check from previous draws
@@ -968,7 +968,6 @@ class GeorgiaFantasy5Predictor:
         odd_count = len(numbers) - even_count
         
         # Decade distribution
-        d0, d1, d2, d3, d4 = self.calculate_decade_distribution(numbers)    ### 250626 ###
         
         # Sequential checks
         seq2, seq3 = self.count_sequential_numbers(numbers)

--- a/ps_cli.py
+++ b/ps_cli.py
@@ -88,13 +88,8 @@ class GeorgiaFantasy5Predictor:
         return mod_total, mod_x
     
     def calculate_decade_distribution(self, numbers):
-<<<<<<< HEAD
-        """Calculate how many numbers fall in each decade (1-9, 10-19, 20-29, 30-42)"""
-        d0, d1, d2, d3, d4 = 0, 0, 0, 0, 0
-=======
         """Calculate how many numbers fall in each decade (1-9, 10-19, 20-29, 30-39, 40-42)"""
-        d0, d1, d2, d3, d4 = 0, 0, 0, 0
->>>>>>> d578328 (update d4 logic 05)
+        d0, d1, d2, d3, d4 = 0, 0, 0, 0, 0
         
         for num in numbers:
             if 1 <= num <= 9:
@@ -397,7 +392,7 @@ class GeorgiaFantasy5Predictor:
         odd_count = len(numbers) - even_count
         
         # Decade distribution
-        d0, d1, d2, d3 = self.calculate_decade_distribution(numbers)
+        d0, d1, d2, d3, d4 = self.calculate_decade_distribution(numbers)
         
         # Sequential checks
         seq2, seq3 = self.count_sequential_numbers(numbers)

--- a/ps_cli.py.bak
+++ b/ps_cli.py.bak
@@ -89,7 +89,7 @@ class GeorgiaFantasy5Predictor:
     
     def calculate_decade_distribution(self, numbers):
         """Calculate how many numbers fall in each decade (1-9, 10-19, 20-29, 30-39, 40-42)"""
-        d0, d1, d2, d3, d4 = 0, 0, 0, 0
+        d0, d1, d2, d3, d4 = 0, 0, 0, 0, 0
         
         for num in numbers:
             if 1 <= num <= 9:
@@ -392,7 +392,7 @@ class GeorgiaFantasy5Predictor:
         odd_count = len(numbers) - even_count
         
         # Decade distribution
-        d0, d1, d2, d3 = self.calculate_decade_distribution(numbers)
+        d0, d1, d2, d3, d4 = self.calculate_decade_distribution(numbers)
         
         # Sequential checks
         seq2, seq3 = self.count_sequential_numbers(numbers)
@@ -409,6 +409,7 @@ class GeorgiaFantasy5Predictor:
             'd1': d1,
             'd2': d2,
             'd3': d3,
+            'd4': d4,
             'seq2': seq2,
             'seq3': seq3,
             'mod_total': mod_total,

--- a/ps_cli2
+++ b/ps_cli2
@@ -214,8 +214,8 @@ def main():
             return False
             
         # Decade distribution check
-        d0, d1, d2, d3 = calculate_decade_distribution(combination)
-        if d0 > 2 or d1 > 2 or d2 > 2 or d3 > 2:
+        d0, d1, d2, d3, d4 = calculate_decade_distribution(combination)
+        if d0 > 2 or d1 > 2 or d2 > 2 or d3 > 2 or d4 > 2:
             return False
             
         # Duplicate check from previous draws

--- a/ps_cli2.bak
+++ b/ps_cli2.bak
@@ -142,7 +142,7 @@ def main():
         return mod_total, mod_x
     
     def calculate_decade_distribution(numbers):
-        d0, d1, d2, d3 = 0, 0, 0, 0
+        d0, d1, d2, d3, d4 = 0, 0, 0, 0, 0
         
         for num in numbers:
             if 1 <= num <= 9:
@@ -153,8 +153,10 @@ def main():
                 d2 += 1
             elif 30 <= num <= 39:
                 d3 += 1
-        
-        return d0, d1, d2, d3
+            else:
+                d4 += 1
+
+        return d0, d1, d2, d3, d4
     
     def check_duplicates_from_previous(numbers, recent_draws, max_draws=3):
         dup_counts = []
@@ -212,8 +214,8 @@ def main():
             return False
             
         # Decade distribution check
-        d0, d1, d2, d3 = calculate_decade_distribution(combination)
-        if d0 > 2 or d1 > 2 or d2 > 2 or d3 > 2:
+        d0, d1, d2, d3, d4 = calculate_decade_distribution(combination)
+        if d0 > 2 or d1 > 2 or d2 > 2 or d3 > 2 or d4 > 2:
             return False
             
         # Duplicate check from previous draws

--- a/ps_cli2.py
+++ b/ps_cli2.py
@@ -214,8 +214,8 @@ def main():
             return False
             
         # Decade distribution check
-        d0, d1, d2, d3 = calculate_decade_distribution(combination)
-        if d0 > 2 or d1 > 2 or d2 > 2 or d3 > 2:
+        d0, d1, d2, d3, d4 = calculate_decade_distribution(combination)
+        if d0 > 2 or d1 > 2 or d2 > 2 or d3 > 2 or d4 > 2:
             return False
             
         # Duplicate check from previous draws

--- a/ps_cli2.py.bak
+++ b/ps_cli2.py.bak
@@ -142,7 +142,7 @@ def main():
         return mod_total, mod_x
     
     def calculate_decade_distribution(numbers):
-        d0, d1, d2, d3 = 0, 0, 0, 0
+        d0, d1, d2, d3, d4 = 0, 0, 0, 0, 0
         
         for num in numbers:
             if 1 <= num <= 9:
@@ -155,8 +155,8 @@ def main():
                 d3 += 1
             else:
                 d4 += 1
-        
-        return d0, d1, d2, d3
+
+        return d0, d1, d2, d3, d4
     
     def check_duplicates_from_previous(numbers, recent_draws, max_draws=3):
         dup_counts = []
@@ -214,8 +214,8 @@ def main():
             return False
             
         # Decade distribution check
-        d0, d1, d2, d3 = calculate_decade_distribution(combination)
-        if d0 > 2 or d1 > 2 or d2 > 2 or d3 > 2:
+        d0, d1, d2, d3, d4 = calculate_decade_distribution(combination)
+        if d0 > 2 or d1 > 2 or d2 > 2 or d3 > 2 or d4 > 2:
             return False
             
         # Duplicate check from previous draws

--- a/ps_flask.py
+++ b/ps_flask.py
@@ -93,13 +93,8 @@ class GeorgiaFantasy5Predictor:
         return mod_total, mod_x
     
     def calculate_decade_distribution(self, numbers):
-<<<<<<< HEAD
-        """Calculate how many numbers fall in each decade (1-9, 10-19, 20-29, 30-39)"""
-        d0, d1, d2, d3, d4 = 0, 0, 0, 0, 0
-=======
         """Calculate how many numbers fall in each decade (1-9, 10-19, 20-29, 30-39, 40-42)"""
-        d0, d1, d2, d3, d4 = 0, 0, 0, 0
->>>>>>> d578328 (update d4 logic 05)
+        d0, d1, d2, d3, d4 = 0, 0, 0, 0, 0
         
         for num in numbers:
             if 1 <= num <= 9:
@@ -399,7 +394,7 @@ class GeorgiaFantasy5Predictor:
         odd_count = len(numbers) - even_count
         
         # Decade distribution
-        d0, d1, d2, d3 = self.calculate_decade_distribution(numbers)
+        d0, d1, d2, d3, d4 = self.calculate_decade_distribution(numbers)
         
         # Sequential checks
         seq2, seq3 = self.count_sequential_numbers(numbers)

--- a/ps_flask.py.bak
+++ b/ps_flask.py.bak
@@ -94,7 +94,7 @@ class GeorgiaFantasy5Predictor:
     
     def calculate_decade_distribution(self, numbers):
         """Calculate how many numbers fall in each decade (1-9, 10-19, 20-29, 30-39, 40-42)"""
-        d0, d1, d2, d3, d4 = 0, 0, 0, 0
+        d0, d1, d2, d3, d4 = 0, 0, 0, 0, 0
         
         for num in numbers:
             if 1 <= num <= 9:
@@ -394,7 +394,7 @@ class GeorgiaFantasy5Predictor:
         odd_count = len(numbers) - even_count
         
         # Decade distribution
-        d0, d1, d2, d3 = self.calculate_decade_distribution(numbers)
+        d0, d1, d2, d3, d4 = self.calculate_decade_distribution(numbers)
         
         # Sequential checks
         seq2, seq3 = self.count_sequential_numbers(numbers)
@@ -411,6 +411,7 @@ class GeorgiaFantasy5Predictor:
             'd1': d1,
             'd2': d2,
             'd3': d3,
+            'd4': d4,
             'seq2': seq2,
             'seq3': seq3,
             'mod_total': mod_total,


### PR DESCRIPTION
## Summary
- normalize calculate_decade_distribution across codebase
- adjust callers to unpack the fifth decade value
- clean up leftover merge markers and comments

## Testing
- `python -m py_compile ps_cli.py ps_flask.py app.py ps_cli2.py`
- `python ps_cli.py --help` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_685d6224fa20832c9b3f6e597c12c3dc