### PR TITLE
Fix decade distribution call in stats calculations

### DIFF
--- a/app.py
+++ b/app.py
@@ -968,6 +968,7 @@ class GeorgiaFantasy5Predictor:
         odd_count = len(numbers) - even_count
         
         # Decade distribution
+        d0, d1, d2, d3, d4 = self.calculate_decade_distribution(numbers)
         # Sequential checks
         seq2, seq3 = self.count_sequential_numbers(numbers)
         

--- a/app.py.bak
+++ b/app.py.bak
@@ -968,6 +968,7 @@ class GeorgiaFantasy5Predictor:
         odd_count = len(numbers) - even_count
         
         # Decade distribution
+        d0, d1, d2, d3, d4 = self.calculate_decade_distribution(numbers)
         
         # Sequential checks
         seq2, seq3 = self.count_sequential_numbers(numbers)


### PR DESCRIPTION
## Summary
- calculate decade distribution in `_calculate_stats`
- apply same fix in backup file

## Testing
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ea1f46b18832c86089de23fc71f49